### PR TITLE
[feature] 주간 팀 기록 수정 기능

### DIFF
--- a/src/api/record.api.ts
+++ b/src/api/record.api.ts
@@ -1,23 +1,28 @@
 import { httpClient } from "./http";
 import { WeeklyTeamRecords } from "../models/WeeklyTeamRecords";
 
-type WeeklyTeamRecordProps = {
-  year: number;
-  week: number;
-};
-
-export const getWeeklyTeamRecord = async ({ year, week }: WeeklyTeamRecordProps) => {
-  const response = await httpClient.get<WeeklyTeamRecords[]>(`/api/weekly?year=${year}&week=${week}`);
+export const getWeeklyTeamRecord = async (date: string) => {
+  const response = await httpClient.get<WeeklyTeamRecords[]>(`/api/weekly?date=${date}`);
   return response.data;
 };
 
-type UpdateWeeklyAchieveProps = {
+export type UpdateWeeklyBooleanProps = {
   mode: string;
   id: number;
-  achieve: boolean;
+  flag: boolean;
 };
 
-export const updateWeeklyAchieve = async ({ mode, id, achieve }: UpdateWeeklyAchieveProps) => {
-  const response = await httpClient.put(`/api/admin/weekly?t=${mode}&id=${id}&achieve=${achieve}`);
+export const updateWeeklyAchieve = async ({ mode, id, flag }: UpdateWeeklyBooleanProps) => {
+  const response = await httpClient.put(`/api/admin/weekly/achieve?t=${mode}&id=${id}&achieve=${flag}`);
+  return response;
+};
+
+export const updateWeeklyCelebrate = async ({ mode, id, flag }: UpdateWeeklyBooleanProps) => {
+  const response = await httpClient.put(`/api/admin/weekly/celebrate?t=${mode}&id=${id}&celebrate=${flag}`);
+  return response;
+};
+
+export const updateWeeklyRecordChange = async (data: WeeklyTeamRecords) => {
+  const response = await httpClient.put("/api/admin/weekly", data);
   return response;
 };

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,22 +1,25 @@
 import { useReducer } from "react";
 import styled from "styled-components";
-import { updateWeeklyAchieve } from "../api/record.api";
 import useToastStore from "../store/ToastStore";
+import { UpdateWeeklyBooleanProps } from "../api/record.api";
 
 type Props = {
-  achieve: boolean;
+  stateProps: boolean;
+  setState: React.Dispatch<React.SetStateAction<boolean>>;
   id: number;
   mode: string;
+  apiFunction: (props: UpdateWeeklyBooleanProps) => Promise<any>;
 };
 
-export default function Checkbox({ achieve, id, mode }: Props) {
-  const [isAchieved, toggleIsAchieved] = useReducer((state) => !state, achieve || false);
+export default function Checkbox({ stateProps, setState, id, mode, apiFunction }: Props) {
+  const [isboolean, toggleIsBoolean] = useReducer((state) => !state, stateProps || false);
   const { addToast } = useToastStore();
 
-  const fetchWeeklyAchieve = () => {
-    updateWeeklyAchieve({ mode, id, achieve: !isAchieved }).then(
+  const fetchChange = () => {
+    apiFunction({ mode, id, flag: !stateProps }).then(
       (response) => {
-        toggleIsAchieved();
+        setState(!stateProps);
+        toggleIsBoolean();
         addToast({ message: "기록 달성 여부 변경에 성공하였습니다.", type: "info" });
       },
       (error) => {
@@ -25,11 +28,7 @@ export default function Checkbox({ achieve, id, mode }: Props) {
     );
   };
 
-  return (
-    <CheckboxStyle>
-      <input type="checkbox" checked={isAchieved} onChange={fetchWeeklyAchieve} />
-    </CheckboxStyle>
-  );
+  return <input type="checkbox" checked={isboolean} onChange={fetchChange} />;
 }
 
 const CheckboxStyle = styled.div``;

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -11,7 +11,7 @@ export default function Dropdown({ children, toggleButton }: Props) {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const { isLoggedIn } = useAuth();
   const dropdownRef = useRef<HTMLDivElement>(null);
-  console.log(isDropdownOpen);
+
   useEffect(() => {
     function handleOutsideClick(e: MouseEvent) {
       if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
@@ -60,5 +60,6 @@ const DropdownStyle = styled.div<DropdownStyleProps>`
     text-align: center;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
     border-radius: ${({ theme }) => theme.borderRadius.default};
+    background-color: white;
   }
 `;

--- a/src/components/EditRecord.tsx
+++ b/src/components/EditRecord.tsx
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+
+type Props = {
+  isEditing: boolean;
+  setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
+  handleRecordChange: () => void;
+};
+
+export default function EditRecord({ isEditing, setIsEditing, handleRecordChange }: Props) {
+  return (
+    <td>
+      {isEditing ? (
+        <>
+          <button onClick={handleRecordChange}>완료</button>
+          <button onClick={() => setIsEditing(!isEditing)}>취소</button>
+        </>
+      ) : (
+        <button onClick={() => setIsEditing(!isEditing)}>수정</button>
+      )}
+    </td>
+  );
+}
+
+const EditRecordStyle = styled.div``;

--- a/src/components/MyCalender.tsx
+++ b/src/components/MyCalender.tsx
@@ -10,18 +10,16 @@ dayjs.extend(weekOfYear);
 
 type Props = {
   handleDateClick: (date: Date) => void;
-  handleActiveStartDateChange: ({ action, activeStartDate, value, view }: any) => void;
   getTileClassName: ({ date, view }: TileClassNameProps) => string | null;
   setDate: React.Dispatch<React.SetStateAction<DateValue>>;
   date: DateValue;
 };
 
-export default function MyCalendar({ handleDateClick, handleActiveStartDateChange, getTileClassName, setDate, date }: Props) {
+export default function MyCalendar({ handleDateClick, getTileClassName, setDate, date }: Props) {
   return (
     <CalendarStyle
       onChange={setDate}
       onClickDay={handleDateClick}
-      onActiveStartDateChange={handleActiveStartDateChange}
       value={date}
       tileClassName={getTileClassName}
       showWeekNumbers={true}

--- a/src/components/RecordRow.tsx
+++ b/src/components/RecordRow.tsx
@@ -1,0 +1,98 @@
+import styled from "styled-components";
+import { useState } from "react";
+import { WeeklyTeamRecords } from "../models/WeeklyTeamRecords";
+import Checkbox from "./Checkbox";
+import EditRecord from "./EditRecord";
+import { teamArr } from "../models/team";
+import { updateWeeklyRecordChange } from "../api/record.api";
+import { updateWeeklyAchieve, updateWeeklyCelebrate } from "../api/record.api";
+import useToastStore from "../store/ToastStore";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import dayjs from "dayjs";
+
+type Props = {
+  record: WeeklyTeamRecords;
+  mode: string;
+  mondayOfWeek: Date;
+};
+
+function lineupTeamArr(defaultTeam: string) {
+  const newTeamArr = teamArr.filter((team) => team !== defaultTeam);
+  newTeamArr.unshift(defaultTeam);
+  return newTeamArr.map((team) => {
+    return (
+      <option key={team} value={team}>
+        {team}
+      </option>
+    );
+  });
+}
+
+export default function RecordRow({ record, mode, mondayOfWeek }: Props) {
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+  const [team, setTeam] = useState(record.team);
+  const [content, setContent] = useState(record.content);
+  const [accSum, setAccSum] = useState(record.accSum);
+  const [remain, setRemain] = useState(record.remain);
+  const [remark, setRemark] = useState(record.remark);
+  const [celebrate, setCelebrate] = useState(record.celebrate);
+  const [achieve, setAchieve] = useState(record.achieve);
+  const [createdAt, setCreatedAt] = useState(record.createdAt);
+  const [achievementDate, setAchievementDate] = useState(record.achievementDate);
+  const { addToast } = useToastStore();
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation({
+    mutationFn: async () => updateWeeklyRecordChange({ id: record.id, team, content, accSum, remain, remark, celebrate, achieve, createdAt, achievementDate }),
+    onSuccess: (response) => {
+      queryClient.invalidateQueries({ queryKey: ["weekly", "record", dayjs(mondayOfWeek).format("YYYY-MM-DD")] });
+      addToast({ message: `${record.team} 기록 변경에 성공하였습니다.`, type: "info" });
+      setIsEditing(false);
+    },
+    onError: (error) => {
+      addToast({ message: `error : ${error} 기록 변경에 실패하였습니다.`, type: "error" });
+    },
+  });
+
+  return (
+    <RecordTrStyle key={record.id}>
+      <td>
+        {isEditing ? (
+          <select value={team} onChange={(e) => setTeam(e.target.value)}>
+            {lineupTeamArr(team)}
+          </select>
+        ) : (
+          record.team
+        )}
+      </td>
+      <td>{isEditing ? <input value={content} onChange={(e) => setContent(e.target.value)} /> : record.content}</td>
+      <td>{isEditing ? <input value={accSum} onChange={(e) => setAccSum(e.target.value)} /> : record.accSum}</td>
+      <td>{isEditing ? <input value={remain} onChange={(e) => setRemain(e.target.value)} /> : record.remain}</td>
+      <td>{isEditing ? <input value={remark} onChange={(e) => setRemark(Number(e.target.value))} /> : `${record.remark}번째`}</td>
+      <td>
+        <Checkbox stateProps={record.celebrate} setState={setCelebrate} id={record.id} mode={mode} apiFunction={updateWeeklyCelebrate} />
+      </td>
+      <td>
+        <Checkbox stateProps={record.achieve} setState={setAchieve} id={record.id} mode={mode} apiFunction={updateWeeklyAchieve} />
+      </td>
+      <td>{isEditing ? <input type="date" value={createdAt} onChange={(e) => setCreatedAt(e.target.value)} /> : record.createdAt}</td>
+      <EditRecord isEditing={isEditing} setIsEditing={setIsEditing} handleRecordChange={mutate} />
+    </RecordTrStyle>
+  );
+}
+
+const RecordTrStyle = styled.tr`
+  input {
+    width: 100%;
+    text-align: center;
+  }
+
+  select {
+    text-align: center;
+  }
+  ul {
+    margin: 5px;
+    padding: 0;
+    list-style-type: none;
+  }
+`;

--- a/src/components/RecordTable.tsx
+++ b/src/components/RecordTable.tsx
@@ -1,14 +1,14 @@
 import styled from "styled-components";
 import { WeeklyTeamRecords } from "../models/WeeklyTeamRecords";
-import { formatCelebrate } from "../lib/formatRecord";
-import Checkbox from "./Checkbox";
+import RecordRow from "./RecordRow";
 
 type Props = {
   records: WeeklyTeamRecords[];
   mode: string;
+  mondayOfWeek: Date;
 };
 
-export default function RecordTable({ records, mode }: Props) {
+export default function RecordTable({ records, mode, mondayOfWeek }: Props) {
   return (
     <RecordTableStyle>
       <table>
@@ -21,24 +21,10 @@ export default function RecordTable({ records, mode }: Props) {
             <td>비고</td>
             <td>시상여부</td>
             <td>달성여부</td>
+            <td>created_at</td>
           </tr>
         </thead>
-        <tbody>
-          {records &&
-            records.map((record) => (
-              <tr key={record.id}>
-                <td>{record.team}</td>
-                <td>{record.content}</td>
-                <td>{record.accSum}</td>
-                <td>{record.remain}</td>
-                <td>{record.remark}번째</td>
-                <td>{formatCelebrate(record.celebrate)}</td>
-                <td>
-                  <Checkbox achieve={record.achieve} id={record.id} mode={mode} />
-                </td>
-              </tr>
-            ))}
-        </tbody>
+        <tbody>{records && records.map((record) => <RecordRow key={record.id} record={record} mode={mode} mondayOfWeek={mondayOfWeek} />)}</tbody>
       </table>
     </RecordTableStyle>
   );

--- a/src/components/RecordUtils.tsx
+++ b/src/components/RecordUtils.tsx
@@ -13,19 +13,15 @@ type Props = {
 };
 
 export default function RecordUtils({ date, weekNum, currentWeekData, copyPrevWeekToCurrent }: Props) {
-  const { data } = useQuery({
-    queryKey: ["weekly", "record", dayjs(date as Date).year(), weekNum - 1],
-    queryFn: () => getWeeklyTeamRecord({ year: dayjs(date as Date).year(), week: weekNum - 1 }),
-    enabled: currentWeekData?.length === 0,
-  });
+  // const { data } = useQuery({
+  //   queryKey: ["weekly", "record", dayjs(date as Date).year(), weekNum - 1],
+  //   queryFn: () => getWeeklyTeamRecord({ year: dayjs(date as Date).year(), week: weekNum - 1 }),
+  //   enabled: currentWeekData?.length === 0,
+  // });
 
-  console.log(data);
+  // console.log(data);
 
-  return (
-    <RecordUtilsStyle>
-      <button onClick={copyPrevWeekToCurrent}>이전 주차 기록 불러오기</button>
-    </RecordUtilsStyle>
-  );
+  return <RecordUtilsStyle>{/* <button onClick={copyPrevWeekToCurrent}>이전 주차 기록 불러오기</button> */}</RecordUtilsStyle>;
 }
 
 const RecordUtilsStyle = styled.div``;

--- a/src/hooks/useWeekRecord.ts
+++ b/src/hooks/useWeekRecord.ts
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getWeeklyTeamRecord } from "../api/record.api";
-import { getWeekRange, compareDate } from "../lib/formatDate";
+import { getWeekRange, compareDate, getMondayDateOfWeek } from "../lib/formatDate";
 import { useQueryClient } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import { WeeklyTeamRecords } from "../models/WeeklyTeamRecords";
@@ -18,25 +18,21 @@ const useWeekRecord = () => {
   const queryClient = useQueryClient();
   // week 달력 관련 상태
   const [date, setDate] = useState<DateValue>(new Date());
+  const [mondayOfWeek, setMondayOfWeek] = useState(() => getMondayDateOfWeek(new Date()));
   const [dateRange, setDateRange] = useState<string[]>(() => getWeekRange(new Date()));
   const [weekNum, setWeekNum] = useState<number>(() => dayjs(new Date()).week());
 
   const { data } = useQuery({
-    queryKey: ["weekly", "record", dayjs(date as Date).year(), weekNum],
-    queryFn: () => getWeeklyTeamRecord({ year: dayjs(date as Date).year(), week: weekNum }),
+    queryKey: ["weekly", "record", dayjs(mondayOfWeek).format("YYYY-MM-DD")],
+    queryFn: () => getWeeklyTeamRecord(dayjs(mondayOfWeek).format("YYYY-MM-DD")),
   });
 
   // week 달력 관련 핸들러
   const handleDateClick = (date: Date) => {
     setDate(date);
+    setMondayOfWeek(getMondayDateOfWeek(date));
     setWeekNum(dayjs(date as Date).week());
     setDateRange(getWeekRange(date));
-  };
-
-  const handleActiveStartDateChange = ({ action, activeStartDate, value, view }: any) => {
-    setWeekNum(dayjs(activeStartDate as Date).week());
-    setDateRange(getWeekRange(activeStartDate));
-    setDate(activeStartDate);
   };
 
   const getTileClassName = ({ date, view }: TileClassNameProps): string | null => {
@@ -55,7 +51,7 @@ const useWeekRecord = () => {
     queryClient.setQueryData(["weekly", "record", dayjs(date as Date).year(), weekNum], removeCompletedData);
   };
 
-  return { weeklyTeamRecords: data, weekNum, getTileClassName, handleActiveStartDateChange, handleDateClick, setDateRange, setDate, setWeekNum, dateRange, date, copyPrevWeekToCurrent };
+  return { weeklyTeamRecords: data, weekNum, getTileClassName, handleDateClick, setDateRange, setDate, mondayOfWeek, setWeekNum, dateRange, date, copyPrevWeekToCurrent };
 };
 
 export default useWeekRecord;

--- a/src/lib/formatDate.ts
+++ b/src/lib/formatDate.ts
@@ -16,10 +16,22 @@ const addDate = (date: DateValue, days: number) => {
 };
 
 export const getWeekRange = (date: DateValue) => {
-  const mondayDateOfWeek = subtractDate(date, (dayjs(date as Date).day() + 6) % 7);
-  const sundayDateOfWeek = addDate(date, (7 - dayjs(date as Date).day()) % 7);
+  const mondayDateOfWeek = dayjs(date as Date)
+    .startOf("week")
+    .add(1, "day")
+    .format(`YYYY-MM-DD`); // 월요일
+  const sundayDateOfWeek = dayjs(date as Date)
+    .endOf("week")
+    .add(1, "day")
+    .format(`YYYY-MM-DD`); // 일요일
 
   return [mondayDateOfWeek, sundayDateOfWeek];
+};
+
+export const getMondayDateOfWeek = (date: DateValue) => {
+  const mondayDateOfWeek = subtractDate(date, (dayjs(date as Date).day() + 6) % 7);
+
+  return new Date(mondayDateOfWeek);
 };
 
 export const compareDate = (selectedDate: Date, dateRange: string[]) => {

--- a/src/models/WeeklyTeamRecords.ts
+++ b/src/models/WeeklyTeamRecords.ts
@@ -1,7 +1,5 @@
 export interface WeeklyTeamRecords {
   id: number;
-  yearColumn: number;
-  week: number;
   team: string;
   content: string;
   accSum: string;
@@ -9,4 +7,6 @@ export interface WeeklyTeamRecords {
   remark: number;
   celebrate: boolean;
   achieve: boolean;
+  createdAt: string;
+  achievementDate: string;
 }

--- a/src/models/team.ts
+++ b/src/models/team.ts
@@ -1,0 +1,1 @@
+export const teamArr = ["SSG", "DOOSAN", "LG", "KIWOOM", "KT", "HANWHA", "KIA", "NC", "SANSUMG", "LOTTE"];

--- a/src/pages/Weekly.tsx
+++ b/src/pages/Weekly.tsx
@@ -5,15 +5,15 @@ import useWeekRecord from "../hooks/useWeekRecord";
 import RecordUtils from "../components/RecordUtils";
 
 export default function Weekly() {
-  const { weeklyTeamRecords, weekNum, handleDateClick, handleActiveStartDateChange, getTileClassName, setDate, date, copyPrevWeekToCurrent } = useWeekRecord();
+  const { weeklyTeamRecords, weekNum, handleDateClick, mondayOfWeek, getTileClassName, setDate, date, copyPrevWeekToCurrent } = useWeekRecord();
 
   if (!weeklyTeamRecords) return null;
 
   return (
     <WeeklyStyle>
-      <RecordTable records={weeklyTeamRecords} mode="team" />
+      <RecordTable records={weeklyTeamRecords} mode="team" mondayOfWeek={mondayOfWeek} />
       <div>
-        <MyCalendar handleDateClick={handleDateClick} handleActiveStartDateChange={handleActiveStartDateChange} getTileClassName={getTileClassName} setDate={setDate} date={date} />
+        <MyCalendar handleDateClick={handleDateClick} getTileClassName={getTileClassName} setDate={setDate} date={date} />
         <RecordUtils date={date} weekNum={weekNum} currentWeekData={weeklyTeamRecords} copyPrevWeekToCurrent={copyPrevWeekToCurrent} />
       </div>
     </WeeklyStyle>

--- a/src/store/ToastStore.ts
+++ b/src/store/ToastStore.ts
@@ -1,4 +1,4 @@
-import create from "zustand";
+import { create } from "zustand";
 
 export type ToastType = "info" | "error";
 


### PR DESCRIPTION
## 주요 내용
- **주간 팀 기록 수정 기능 구현**
- db 스키마 변경으로 인하여, 이전 주차의 데이터 중 완료되지 않은 데이터를 가지고 오는 것을 기본 동작으로 수행
- 따라서 이전 주차 기록 가지고오는 버튼 삭제
- 주간 데이터는 특정 날짜를 선택 시 그 주 월요일이 상태값으로 저장되어 data fetching의 기준이 됨
- celebrate, achieve api 변경 사항 반영
- getWeekRange 로직 수정(dayjs 활용)
