### PR TITLE
[fix] daily-api 

### DIFF
--- a/src/api/record.api.ts
+++ b/src/api/record.api.ts
@@ -27,6 +27,11 @@ export const updateCelebrate = async ({ mode, id, target, flag }: UpdateWeeklyBo
   return response;
 };
 
+export const updateIsFail = async ({ id, flag }: { id: number; flag: boolean }) => {
+  const response = await httpClient.put(`/api/admin/record/fail?id=${id}&fail=${flag}`);
+  return response;
+};
+
 export const updateRecord = async ({ data, target, mode }: { data: IWeeklyTeamRecord | IWeeklyPlayerRecord; target: "weekly" | "daily"; mode?: "team" | "player" }) => {
   const url = `/api/admin/record?t=${target}${mode ? `&m=${mode}` : ""}`;
   const response = await httpClient.put(url, data);

--- a/src/components/RecordRow.tsx
+++ b/src/components/RecordRow.tsx
@@ -3,7 +3,7 @@ import { IWeeklyTeamRecord } from "../models/WeeklyTeamRecords";
 import { IWeeklyPlayerRecord } from "@/models/WeeklyPlayerRecord";
 import Checkbox from "./Checkbox";
 import EditRecord from "./EditRecord";
-import { updateAchieve, updateCelebrate } from "@/api/record.api";
+import { updateAchieve, updateCelebrate, updateIsFail } from "@/api/record.api";
 import TeamSelect from "./TeamSelect";
 import useEditRecord from "../hooks/useEditRecord";
 import PlayerSearch from "./PlayerSearch";
@@ -17,7 +17,7 @@ type Props = {
 };
 
 export default function RecordRow({ record, date, setDeleteTargets, deleteTargets, target }: Props) {
-  const { player, setPlayer, isEditing, recordState, setCelebrate, setAchieve, handleInputChange, mutation, setIsEditing, handleDeleteTarget, isDeleteChecked } = useEditRecord({
+  const { player, setPlayer, isEditing, recordState, setCelebrate, setAchieve, handleInputChange, mutation, setIsEditing, handleDeleteTarget, isDeleteChecked, isFail, setIsFail } = useEditRecord({
     record,
     date,
     setDeleteTargets,
@@ -53,6 +53,11 @@ export default function RecordRow({ record, date, setDeleteTargets, deleteTarget
       <td>
         <Checkbox stateProps={record.achieve} setState={setAchieve} recordId={record.id} mode={"playerId" in record ? "player" : "team"} apiFunction={updateAchieve} target={target} />
       </td>
+      {"isFail" in record && record.isFail !== undefined && (
+        <td>
+          <Checkbox stateProps={record.isFail} setState={setIsFail} recordId={record.id} mode={"playerId" in record ? "player" : "team"} apiFunction={updateIsFail} target={target} />
+        </td>
+      )}
       <td>{isEditing ? <input type="date" name="createdAt" value={recordState.createdAt} onChange={(e) => handleInputChange(e)} /> : record.createdAt}</td>
       <EditRecord isEditing={isEditing} setIsEditing={setIsEditing} handleRecordChange={mutation.mutate} />
     </RecordTrStyle>

--- a/src/components/RecordTable.tsx
+++ b/src/components/RecordTable.tsx
@@ -25,7 +25,8 @@ export default function RecordTable({ records, date, deleteTargets, setDeleteTar
             <td>잔여기록</td>
             <td>비고</td>
             <td>시상여부</td>
-            <td>달성여부</td>
+            <td>달성완료</td>
+            {"isFail" in records[0] && <td>달성 실패</td>}
             <td>created_at</td>
           </tr>
         </thead>

--- a/src/hooks/useEditRecord.ts
+++ b/src/hooks/useEditRecord.ts
@@ -22,6 +22,10 @@ const useEditRecord = ({ record, date, setDeleteTargets, deleteTargets, target }
   const [recordState, setRecordState] = useState<Omit<IWeeklyTeamRecord, "id" | "achieve" | "celebrate">>({ ...record });
   const [celebrate, setCelebrate] = useState(record.celebrate);
   const [achieve, setAchieve] = useState(record.achieve);
+  const [isFail, setIsFail] = useState<boolean>(() => {
+    return "isFail" in record ? record.isFail ?? false : false;
+  });
+
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [player, setPlayer] = useState<TPlayer | null>(() => ("playerId" in record ? { id: record.playerId, player: record.player, team: record.team, uniformNumber: record.uniformNumber } : null));
   const { addToast } = useToastStore();
@@ -74,7 +78,7 @@ const useEditRecord = ({ record, date, setDeleteTargets, deleteTargets, target }
     },
   });
 
-  return { player, setPlayer, isEditing, recordState, celebrate, achieve, setCelebrate, setAchieve, handleInputChange, mutation, setIsEditing, handleDeleteTarget, isDeleteChecked };
+  return { player, setPlayer, isEditing, recordState, celebrate, achieve, setCelebrate, setAchieve, handleInputChange, mutation, setIsEditing, handleDeleteTarget, isDeleteChecked, isFail, setIsFail };
 };
 
 export default useEditRecord;

--- a/src/models/DailyRecords.ts
+++ b/src/models/DailyRecords.ts
@@ -1,6 +1,5 @@
 import { TeamType } from "./team";
-
-export interface IWeeklyPlayerRecord {
+export interface IDailyPlayerRecord {
   id: number;
   content: string;
   accSum: string;
@@ -8,18 +7,11 @@ export interface IWeeklyPlayerRecord {
   remark: number;
   celebrate: boolean;
   achieve: boolean;
+  isFail: boolean;
   createdAt: string;
   achievementDate: string | null;
   playerId: number;
   player: string;
   team: TeamType;
   uniformNumber: number;
-  isFail?: boolean;
 }
-
-export type TPlayer = {
-  id: number;
-  player: string;
-  team: TeamType;
-  uniformNumber: number;
-};


### PR DESCRIPTION
## 작업 내용
+ 일간 기록에 isFail 컬럼 추가 -> 연속 안타, 연승 등 실패 가능한 기록을 처리하기 위해서 -> 이에 따라 ui, api 수정
